### PR TITLE
89 adding boards

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,9 @@ matrix:
     - os: osx
       env: BADGE=linux
 
-before_install: gem install bundler -v 1.15.4
+before_install:
+- gem install bundler -v 1.15
+- bundler _1.15_ install
 script:
    - g++ -v
    - bundle install

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,11 +17,13 @@ matrix:
     - os: osx
       env: BADGE=linux
 
-before_install:
-- gem install bundler -v 1.15
-- bundler _1.15_ install
+#before_install:
+#- gem install bundler -v 1.15
+#- bundler _1.15_ install
 script:
    - g++ -v
+   - bundle install bundled -v 1.15
+   - bundler _1.15_ install
    - bundle install
    - bundle exec rubocop --version
    - bundle exec rubocop -D .

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
 #- bundler _1.15_ install
 script:
    - g++ -v
-   - bundle install bundled -v 1.15
+   - bundle install bundler -v 1.15
    - bundler _1.15_ install
    - bundle install
    - bundle exec rubocop --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ matrix:
       env: BADGE=linux
 
 #before_install:
-- gem install bundler -v 1.15.4
-- bundle _1.15_ install
+  - gem install bundler -v 1.15.4
+  - bundle _1.15_ install
 script:
    - g++ -v
    #- gem install bundle -v 1.15.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
     - os: osx
       env: BADGE=linux
 
-#before_install:
+before_install:
   - gem install bundler -v 1.15.4
   - bundle _1.15_ install
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
 #- bundler _1.15_ install
 script:
    - g++ -v
-   - bundle install bundler -v 1.15
+   - bundler install bundler -v 1.15
    - bundler _1.15_ install
    - bundle install
    - bundle exec rubocop --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,12 +18,12 @@ matrix:
       env: BADGE=linux
 
 #before_install:
-#- gem install bundler -v 1.15
-#- bundler _1.15_ install
+- gem install bundler -v 1.15.4
+- bundle _1.15_ install
 script:
    - g++ -v
-   - gem install bundler -v 1.15
-   - bundler _1.15_ install
+   #- gem install bundle -v 1.15.4
+   #- bundle _1.15_ install
    - bundle install
    - bundle exec rubocop --version
    - bundle exec rubocop -D .

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
 
 before_install:
   - gem install bundler -v 1.15.4
-  - bundle _1.15_ install
+  - bundler _1.15_ install
 script:
    - g++ -v
    #- gem install bundle -v 1.15.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
 
 before_install:
   - gem install bundler -v 1.15.4
-  - bundler _1.15_ install
+  - bundle _1.15.4_ install
 script:
    - g++ -v
    #- gem install bundle -v 1.15.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
     - os: osx
       env: BADGE=linux
 
-#before_install: gem install bundler -v 1.15.4
+before_install: gem install bundler -v 1.15.4
 script:
    - g++ -v
    - bundle install

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
 #- bundler _1.15_ install
 script:
    - g++ -v
-   - bundler install bundler -v 1.15
+   - gem install bundler -v 1.15
    - bundler _1.15_ install
    - bundle install
    - bundle exec rubocop --version

--- a/misc/default.yml
+++ b/misc/default.yml
@@ -55,7 +55,7 @@ platforms:
         # use the mega form factor
         #- __ATSAM3X8E__
         #- __AVR_ATmega2560__
-        #- __AVR_ATmega328__
+        - __AVR_ATmega328__
       warnings:
       flags:
   zero:

--- a/misc/default.yml
+++ b/misc/default.yml
@@ -49,7 +49,13 @@ platforms:
     gcc:
       features:
       defines:
-        - __ATSAM3X8E__
+        # The due should use the ATSAM3X8E; however, that component does not seem
+        # to be defined for the Godmode tests/components
+        # The next closest part would be the AVR_ATmega2560 as both boards
+        # use the mega form factor
+        #- __ATSAM3X8E__
+        #- __AVR_ATmega2560__
+        #- __AVR_ATmega328__
       warnings:
       flags:
   zero:

--- a/misc/default.yml
+++ b/misc/default.yml
@@ -54,8 +54,8 @@ platforms:
         # The next closest part would be the AVR_ATmega2560 as both boards
         # use the mega form factor
         #- __ATSAM3X8E__
-        #- __AVR_ATmega2560__
-        - __AVR_ATmega328__
+        - __AVR_ATmega2560__
+        #- __AVR_ATmega328__
       warnings:
       flags:
   zero:


### PR DESCRIPTION
## Additions

## Changes
* Due now builds with defines for ATmega2560 as that is closer to the ATSAM3X8E (ATSAM3X8E causes Godmode tests to fail currently)
* Modified Travis-CI build to install bundler 1.15.4 as the current bundle expects this version

## Limitations
* No custom board definitions were added, this may or may not matter?  May possibly need for Godmode?

## Issues
* Does not currently use the correct definitions for the arduino Due, see 'Changes'